### PR TITLE
Torrent struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,21 @@ mod utils;
 /// is advised to change this**
 pub const CLIENT_PREFIX: &str = "TO";
 
+/// Represents the overall torrent directory structure for a given [Torrent]
+///
+/// This merges the [BEP0003](https://www.bittorrent.org/beps/bep_0003.html) spec
+/// of either a single `length` for a file given or a list of dictionaries into
+/// this singular enum for easier comprehension
+pub enum TorrentFile {
+    /// A single file with a [usize] determining it's length in bytes (`1` in
+    /// usize == 1 byte)
+    Single(usize),
+
+    /// Multiple files with a similar [usize] but also a path that decends into
+    /// the [Torrent::name] directory
+    MultiFile(Vec<(usize, String)>),
+}
+
 /// The primary representation of a torrent, created from the [parse](crate::parser::parse)
 /// function. This representation is used to interact with many parts of torro.
 ///
@@ -78,6 +93,35 @@ pub struct Torrent {
     /// the piece at the corresponding index.
     /// ```
     pub pieces: Vec<String>,
-    
-    // TODO: Finish adding values from https://www.bittorrent.org/beps/bep_0003.html
+
+    /// The overall file structure of the torrent, see the [TorrentFile] enum for
+    /// more infomation
+    ///
+    /// # BitTorrent Description
+    ///
+    /// *We have merged the two options into a single enum for easier digesting
+    /// inside of Rust*
+    ///
+    /// ```none
+    /// There is also a key length or a key files, but not both or neither. If
+    /// length is present then the download represents a single file, otherwise
+    /// it represents a set of files which go in a directory structure.
+    ///
+    /// In the single file case, length maps to the length of the file in bytes.
+    ///
+    /// For the purposes of the other keys, the multi-file case is treated as
+    /// only having a single file by concatenating the files in the order they
+    /// appear in the files list. The files list is the value files maps to, and
+    /// is a list of dictionaries containing the following keys:
+    ///
+    /// length - The length of the file, in bytes.
+    ///
+    /// path - A list of UTF-8 encoded strings corresponding to subdirectory names,
+    /// the last of which is the actual file name (a zero length list is an error
+    /// case).
+    ///
+    /// In the single file case, the name key is the name of a file, in the
+    /// muliple file case, it's the name of a directory.
+    /// ```
+    pub file_structure: TorrentFile,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,62 @@ mod utils;
 /// **If this library is forked and used heavily in a production enviroment, it
 /// is advised to change this**
 pub const CLIENT_PREFIX: &str = "TO";
+
+/// The primary representation of a torrent, created from the [parse](crate::parser::parse)
+/// function. This representation is used to interact with many parts of torro.
+///
+/// *All "BitTorrent Description" headings are taken from
+/// [BEP0003](https://www.bittorrent.org/beps/bep_0003.html) and is subject to
+/// change, like any moving standard. This documentation is based off of version
+/// `0e08ddf84d8d3bf101cdf897fc312f2774588c9e`*
+pub struct Torrent {
+    /// URL for tracker
+    ///
+    /// # BitTorrent Description
+    ///
+    /// ```none
+    /// The URL of the tracker.
+    /// ```
+    pub announce_url: String,
+
+    /// Advised save name for torrent once leeched, is use by torro by default
+    /// but may be changed
+    ///
+    /// # BitTorrent Description
+    ///
+    /// ```none
+    /// The `name` key maps to a UTF-8 encoded string which is the suggested name
+    /// to save the file (or directory) as. It is purely advisory.
+    /// ```
+    pub name: String, // TODO: allow changing once implemented
+
+    /// File buffer (aka piece) length, commonly a power of 2 (e.g. `2`, `4`,
+    /// `8`, `16`)
+    ///
+    /// # BitTorrent Description
+    ///
+    /// ```none
+    /// `piece` length maps to the number of bytes in each piece the file is split
+    /// into. For the purposes of transfer, files are split into fixed-size pieces
+    /// which are all the same length except for possibly the last one which may
+    /// be truncated. piece length is almost always a power of two, most commonly
+    /// 2 18 = 256 K (BitTorrent prior to version 3.2 uses 2 20 = 1 M as default).
+    /// ```
+    pub piece: usize,
+
+    /// A vector of SHA hashes corrosponding to each [Torrent::piece]
+    ///
+    /// # BitTorrent Description
+    ///
+    /// *Please note that torro represents this "string whose length is a multiple
+    /// of 20" as a [Vec]<[String]> with each string containing a hash for simplicity*
+    ///
+    /// ```none
+    /// `pieces` maps to a string whose length is a multiple of 20. It is to be
+    /// subdivided into strings of length 20, each of which is the SHA1 hash of
+    /// the piece at the corresponding index.
+    /// ```
+    pub pieces: Vec<String>,
+    
+    // TODO: Finish adding values from https://www.bittorrent.org/beps/bep_0003.html
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -492,12 +492,12 @@ mod tests {
         );
     }
 
-    /// Ensures that [parse] properly matches to the desired type
+    /// Ensures that [parse_to_bencodeobj] properly matches to the desired type
     #[test]
-    fn parse_correctness() {
-        assert_eq!(parse("i32e"), Ok(vec![BencodeObj::Int(32)]));
+    fn parse_bencodeobj_correctness() {
+        assert_eq!(parse_to_bencodeobj("i32e"), Ok(vec![BencodeObj::Int(32)]));
         assert_eq!(
-            parse("4:test8:working?i1e"),
+            parse_to_bencodeobj("4:test8:working?i1e"),
             Ok(vec![
                 BencodeObj::Str(String::from("test")),
                 BencodeObj::Str(String::from("working?")),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,8 @@
-//! Contains `.torrent` (bencode) parsing-related functions. See [parse] and it's
-//! returned [BencodeObj] vector for more infomation regarding torrent parsing.
+//! Contains `.torrent` (bencode) parsing-related functions. See [parse] or it's
+//! returned [Torrent] structure (contained at the root level of
+//! torro) for more infomation regarding torrent parsing.
+
+use crate::Torrent;
 
 /// Control char for detecting int starts
 const INT_START: char = 'i';
@@ -41,7 +44,9 @@ pub enum ParseError {
     LeadingZeros,
 }
 
-/// Parsed `.torrent` (bencode) file line, containing a variety of outcomes
+/// Parsed `.torrent` (bencode) file line, containing a variety of outcomes. This
+/// is only used internally, see [Torrent] for publically
+/// returned parsing
 #[derive(Debug, PartialEq, Clone)]
 pub enum BencodeObj {
     /// Similar to a HashMap
@@ -129,14 +134,14 @@ fn match_until(
     query: TokenType,
     token_iter: &mut std::iter::Peekable<std::slice::Iter<TokenType>>,
 ) -> Result<Vec<BencodeObj>, ParseError> {
-    let mut output_vec = vec![];
+    let mut bencode_vec = vec![];
     let mut peeked_token = match token_iter.peek() {
         Some(p) => p,
         None => return Err(ParseError::UnexpectedEOF),
     };
 
     while peeked_token != &&query {
-        output_vec.push(match_next_bencodeobj(peeked_token, token_iter)?);
+        bencode_vec.push(match_next_bencodeobj(peeked_token, token_iter)?);
         peeked_token = match token_iter.peek() {
             Some(p) => p,
             None => return Err(ParseError::UnexpectedEOF),
@@ -145,7 +150,7 @@ fn match_until(
 
     token_iter.next(); // consume queried token
 
-    Ok(output_vec)
+    Ok(bencode_vec)
 }
 
 /// Iterates over token_iter and adds to output vec until query is found then
@@ -254,8 +259,10 @@ fn decode_list(
 }
 
 /// Parses `.torrent` (bencode) file into a [BencodeObj] for each line
-pub fn parse(data: &str) -> Result<Vec<BencodeObj>, ParseError> {
-    let mut output_vec = vec![];
+///
+/// **See [parse] or [parse_str] if you'd like to parse into [Torrent]s**
+pub fn parse_to_bencodeobj(data: &str) -> Result<Vec<BencodeObj>, ParseError> {
+    let mut bencode_vec = vec![];
     let scanned_data = scan_data(data);
 
     let mut token_iter = scanned_data.iter().peekable();
@@ -266,14 +273,20 @@ pub fn parse(data: &str) -> Result<Vec<BencodeObj>, ParseError> {
             None => break,
         };
 
-        output_vec.push(match_next_bencodeobj(peeked_token, &mut token_iter)?);
+        bencode_vec.push(match_next_bencodeobj(peeked_token, &mut token_iter)?);
     }
 
-    Ok(output_vec)
+    Ok(bencode_vec)
+}
+
+/// Creates a [Torrent] from given data by piping results from [parse_to_bencodeobj]
+/// into a new [Torrent] structure
+pub fn parse(data: &str) -> Result<Torrent, ParseError> {
+    unimplemented!();
 }
 
 /// Alias for [parse] which allows a [String] `data` rather than a &[str] `data`
-pub fn parse_str(data: String) -> Result<Vec<BencodeObj>, ParseError> {
+pub fn parse_str(data: String) -> Result<Torrent, ParseError> {
     parse(&data)
 }
 


### PR DESCRIPTION
A new `Torrent` structure has been added, acting as the "key" for the library once parsed by the `parse` function